### PR TITLE
自動更新機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,3 +64,4 @@ gem 'factory_bot_rails'
 gem 'faker'
 gem "jquery-rails"
 gem 'pry-rails'
+gem 'turbolinks', '~> 5'

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -24,7 +24,6 @@ $(function() {
   var reloadMessages = function() {
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
       var last_message_id = $('.message:last').data("message-id"); 
-      console.log(last_message_id)
       $.ajax({
         url: 'api/messages', 
         type: 'get',
@@ -32,7 +31,6 @@ $(function() {
         data: {last_id: last_message_id}
       })
       .done(function(messages) {
-        console.log(messages)
         var insertHTML = '';
         messages.forEach(function (message) {
           insertHTML = buildHTML(message);
@@ -49,7 +47,6 @@ $(function() {
   $('#new_message').on('submit', function(e){
     $("#new_message").prop('disabled', false);
     e.preventDefault(); 
-    console.log(this)
     var formData = new FormData(this);
     var url = $(this).attr('action')
     $.ajax({

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,8 @@
 $(function() {
-  function buildHTML(message){
-    if ( message.image ) {
-      var html =
-        `<div class="message" data-message-id=${message.id}>
+  function buildHTML(message) {
+    image = (message.image) ? `<img class= "lower-message__image" src=${message.image} >` : ""; 
+
+    var html = `<div class="message" data-message-id="${message.id}"> 
           <div class="upper-message">
             <div class="upper-message__user-name">
               ${message.user_name}
@@ -11,36 +11,43 @@ $(function() {
               ${message.date}
             </div>
           </div>
-          <div class="lower-message">
+          <div class="lower-meesage">
             <p class="lower-message__content">
               ${message.content}
             </p>
-          </div>
-          <img src=${""} >
-        </div>`
-      return html;
-    } else {
-      var html =
-        `<div class="message" data-message-id=${message.id}>
-          <div class="upper-message">
-            <div class="upper-message__user-name">
-              ${message.user_name}
-            </div>
-            <div class="upper-message__date">
-              ${message.date}
-            </div>
-          </div>
-          <div class="lower-message">
-           <p class="lower-message__content">
-              ${message.content}
-            </p>
+            ${image}
           </div>
         </div>`
-      return html;
-    };
+    return html;
+  
   }
-$('#new_message').on('submit', function(e){
-  $("#new_message").prop('disabled', false);
+  var reloadMessages = function() {
+    if (window.location.href.match(/\/groups\/\d+\/messages/)){
+      var last_message_id = $('.message:last').data("message-id"); 
+      console.log(last_message_id)
+      $.ajax({
+        url: 'api/messages', 
+        type: 'get',
+        detatype: 'json',
+        data: {last_id: last_message_id}
+      })
+      .done(function(messages) {
+        console.log(messages)
+        var insertHTML = '';
+        messages.forEach(function (message) {
+          insertHTML = buildHTML(message);
+          $('.messages').append(insertHTML);
+        })
+        $('.messsages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+      })
+      .fail(function() {
+        alert('自動更新に失敗しました');
+      });
+    }
+  
+  };
+  $('#new_message').on('submit', function(e){
+    $("#new_message").prop('disabled', false);
     e.preventDefault(); 
     console.log(this)
     var formData = new FormData(this);
@@ -53,15 +60,16 @@ $('#new_message').on('submit', function(e){
       processData: false,
       contentType: false
     })
-     .done(function(data) {
-       var html = buildHTML(data);
-       $('.messages').append(html);
-       $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');   
-       $('form')[0].reset();
-     })
-      .fail(function(){
-        alert("メッセージ送信に失敗しました");
-      });
-      return false;
+    .done(function(data) {
+      console.log(data)
+      var html = buildHTML(data);
+      $('.messages').append(html);
+      $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');   
+      $('form')[0].reset();
+    })
+    .fail(function(){
+      alert("メッセージ送信に失敗しました");
     });
+  });
+  setInterval(reloadMessages,5000);
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:last_id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content      message.content
+  json.image        message.image.url
+  json.date         message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.user_name    message.user.name
+  json.id           message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,10 +1,11 @@
-.upper-message
-  .upper-message__user-name
-    = message.user.name
-  .upper-message__date
-    = message.created_at.strftime("%Y/%m/%d %H:%M")
-.lower-message
-  - if message.content.present?
-    %p.lower-message__content
-      = message.content
-  = image_tag message.image.url, class: 'lower-message__image' if message.image.present?
+.message{"data-message-id": "#{message.id}"}
+  .upper-message
+    .upper-message__user-name
+      = message.user.name
+    .upper-message__date
+      = message.created_at.strftime("%Y/%m/%d %H:%M")
+  .lower-message
+    - if message.content.present?
+      %p.lower-message__content
+        = message.content
+    = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
-json.id @message.id
+json.content @message.content 
+json.image @message.image.url
+json.created_at @message.created_at
 json.user_name @message.user.name
-json.data @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json'}
+    end
   end
 end


### PR DESCRIPTION


# what
表示されているメッセージのHTMLにid情報を追加
メッセージを更新するためのアクションを実装
追加したアクションを動かすためのルーティングを実装
追加したアクションをリクエストするよう実装
取得した最新のメッセージをブラウザのメッセージ一覧に追加
数秒ごとにリクエストするよう実装
メッセージ分だけスクロールするよう実装
メッセージ一覧のページでのみJSが動くよう実装
#why
アクションの中で、DBからのメッセージの検索条件として必要となる
新しく追加されたメッセージの分だけメッセージ表示部分を上にスクロールする
一定時間が経過するごとに処理を実行する
グループのメッセージ一覧ページである場合には自動更新を実行し、そうでない場合には実行しないコードを書きましょう